### PR TITLE
Added git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ EXPOSE 5000
 RUN apt-get update \
     && apt-get install -y  \
     curl \
+    git \
     graphviz  \
     python3 \
     python3-pip \


### PR DESCRIPTION
When using custom modules hosted on GitHub git is necessary to download them.